### PR TITLE
Use STS channel argument for dotnet installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl=7.68.0-1ub
 # Installation script for Git LFS, Node.js and .NET SDK
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
-    && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir /usr/share/dotnet \
+    && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel STS --install-dir /usr/share/dotnet \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list


### PR DESCRIPTION
### Main Changes

- Use STS channel argument for dotnet installation (b9c078f)

### Context

This warning was detected in the logs, [see](https://github.com/UlisesGascon/development-toolkit/actions/runs/6944589418/job/18892034909)

![Screenshot 2023-11-21 at 14 42 01](https://github.com/UlisesGascon/development-toolkit/assets/5110813/090da029-f1b1-4ae9-9f2a-c7645a5007b3)


### Changelog

- b9c078f Use STS channel argument for dotnet installation by @UlisesGascon 