### PR TITLE
Upgrade opinionated-bash-scripts to 0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git-lfs=3.4.0 n
 
 # Install Opinionated bash scripts
 WORKDIR /home
-RUN curl -L https://github.com/UlisesGascon/opinionated-bash-scripts/archive/refs/tags/0.1.0.tar.gz | tar zx \
+RUN curl -L https://github.com/UlisesGascon/opinionated-bash-scripts/archive/refs/tags/0.2.0.tar.gz | tar zx \
     && mkdir /usr/share/opinionated-bash-scripts \
     && chmod +x opinionated-bash-scripts*/scripts/*.sh \
     && mv opinionated-bash-scripts*/* /usr/share/opinionated-bash-scripts \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Personal Docker image used for development
 - g++ 4:9.3.0
 - make 4.2.1
 - fastjar 2:0.98
-- [UlisesGascon/opinionated-bash-scripts](https://github.com/UlisesGascon/opinionated-bash-scripts) 0.1.0
+- [UlisesGascon/opinionated-bash-scripts](https://github.com/UlisesGascon/opinionated-bash-scripts) 0.2.0
 
 ### Usage
 


### PR DESCRIPTION
### Main Changes
- Upgrade opinionated-bash-scripts to 0.2.0 (90bfe76)

### Changelog
- 90bfe76 chore: upgrade opinionated-bash-scripts to 0.2.0 by @UlisesGascon
