### PR TITLE
feat: add e2e tests to CI pipeline

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,9 +9,21 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install Node@20
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      with:
+        node-version: 20.9.0
+        registry-url: https://registry.npmjs.org
+
     - uses: hadolint/hadolint-action@v3.1.0
       with:
         dockerfile: Dockerfile
 
     - name: Build container image
       run: docker build -t ulisesgascon/development-toolkit:latest .
+
+    - name: Install Node.js dependencies
+      run: npm ci
+
+    - name: Run E2E Test
+      run: npm run test


### PR DESCRIPTION
### Main Changes
- Add e2e tests to CI pipeline (671edeb)

### Reference

Test are passing in CI, [see](https://github.com/UlisesGascon/development-toolkit/actions/runs/6948748584/job/18905379846):
```
PASS __tests__/immutability.test.js (12.915 s)
  Immutability
    Core
      ✓ Installed packages (151 ms)
    Core Extended packages
      ✓ Git version (87 ms)
      ✓ Git LFS version (104 ms)
      ✓ Docker version (101 ms)
      ✓ Curl version (97 ms)
      ✓ net-tools: netstat version (91 ms)
      ✓ gnupg: gpg version (81 ms)
      ✓ libcurl4-openssl-dev version (95 ms)
      ✓ gcc version (101 ms)
      ✓ g++ version (83 ms)
      ✓ make version (99 ms)
      ✓ fastjar: jar version (83 ms)
    Development packages
      ✓ Node version (100 ms)
      ✓ NPM version (324 ms)
      ✓ Dotnet runtimes list (111 ms)
      ✓ Dotnet SDKs list (91 ms)
      ✓ opinionated-bash-scripts version (94 ms)
``` 
### Changelog
- 671edeb feat: add e2e tests to CI pipeline by @UlisesGascon