### PR TITLE
Upgrade opinionated-bash-scripts to 0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git-lfs=3.4.0 n
 
 # Install Opinionated bash scripts
 WORKDIR /home
-RUN curl -L https://github.com/UlisesGascon/opinionated-bash-scripts/archive/refs/tags/0.2.1.tar.gz | tar zx \
+RUN curl -L https://github.com/UlisesGascon/opinionated-bash-scripts/archive/refs/tags/0.3.0.tar.gz | tar zx \
     && mkdir /usr/share/opinionated-bash-scripts \
     && chmod +x opinionated-bash-scripts*/scripts/*.sh \
     && mv opinionated-bash-scripts*/* /usr/share/opinionated-bash-scripts \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Personal Docker image used for development
 - g++ 4:9.3.0
 - make 4.2.1
 - fastjar 2:0.98
-- [UlisesGascon/opinionated-bash-scripts](https://github.com/UlisesGascon/opinionated-bash-scripts) 0.2.1
+- [UlisesGascon/opinionated-bash-scripts](https://github.com/UlisesGascon/opinionated-bash-scripts) 0.3.0
 
 ### Usage
 

--- a/__tests__/__snapshots__/immutability.test.js.snap
+++ b/__tests__/__snapshots__/immutability.test.js.snap
@@ -327,7 +327,9 @@ exports[`Immutability Development packages Node version 1`] = `
 `;
 
 exports[`Immutability Development packages opinionated-bash-scripts version 1`] = `
-"get_version () {
+"#!/bin/bash
+
+get_version () {
     echo "Current version: 0.3.0"
     echo "Source code: https://github.com/UlisesGascon/opinionated-bash-scripts/releases/tag/0.3.0"
 }"

--- a/__tests__/__snapshots__/immutability.test.js.snap
+++ b/__tests__/__snapshots__/immutability.test.js.snap
@@ -328,7 +328,7 @@ exports[`Immutability Development packages Node version 1`] = `
 
 exports[`Immutability Development packages opinionated-bash-scripts version 1`] = `
 "get_version () {
-    echo "Current version: 0.2.1"
-    echo "Source code: https://github.com/UlisesGascon/opinionated-bash-scripts/releases/tag/0.2.1"
+    echo "Current version: 0.3.0"
+    echo "Source code: https://github.com/UlisesGascon/opinionated-bash-scripts/releases/tag/0.3.0"
 }"
 `;


### PR DESCRIPTION
### Main Changes
- Upgrade `opinionated-bash-scripts` to 0.3.0 (1e9c572)
- Update the snapshot for tests (1ca676d)

### Changelog
- 1e9c572 chore: upgrade `opinionated-bash-scripts` to 0.3.0 by @UlisesGascon
- 1ca676d test: update the snapshot by @UlisesGascon
