### PR TITLE
Upgrade opinionated-bash-scripts to 0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/v2.23.3/docker-
 
 # Install Opinionated bash scripts
 WORKDIR /home
-RUN curl -L https://github.com/UlisesGascon/opinionated-bash-scripts/archive/refs/tags/0.3.0.tar.gz | tar zx \
+RUN curl -L https://github.com/UlisesGascon/opinionated-bash-scripts/archive/refs/tags/0.4.0.tar.gz | tar zx \
     && mkdir /usr/share/opinionated-bash-scripts \
     && chmod +x opinionated-bash-scripts*/scripts/*.sh \
     && mv opinionated-bash-scripts*/* /usr/share/opinionated-bash-scripts \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Personal Docker image used for development
 - nano 4.8
 - iputils-ping 3:20190709-3
 - apt-transport-https 2.0.10
-- [UlisesGascon/opinionated-bash-scripts](https://github.com/UlisesGascon/opinionated-bash-scripts) 0.3.0
+- [UlisesGascon/opinionated-bash-scripts](https://github.com/UlisesGascon/opinionated-bash-scripts) 0.4.0
 
 ### Usage
 

--- a/__tests__/__snapshots__/immutability.test.js.snap
+++ b/__tests__/__snapshots__/immutability.test.js.snap
@@ -353,7 +353,7 @@ exports[`Immutability Development packages opinionated-bash-scripts version 1`] 
 "#!/bin/bash
 
 get_version () {
-    echo "Current version: 0.3.0"
-    echo "Source code: https://github.com/UlisesGascon/opinionated-bash-scripts/releases/tag/0.3.0"
+    echo "Current version: 0.4.0"
+    echo "Source code: https://github.com/UlisesGascon/opinionated-bash-scripts/releases/tag/0.4.0"
 }"
 `;


### PR DESCRIPTION
### Main Changes
- Upgrade opinionated-bash-scripts to 0.4.0 (df02bc6)

### Changelog
- df02bc6 chore: upgrade opinionated-bash-scripts to 0.4.0 by @UlisesGascon
